### PR TITLE
Fix 579 2

### DIFF
--- a/tests/test_runners.py
+++ b/tests/test_runners.py
@@ -108,6 +108,67 @@ def test_integrate_double_nvt(
     assert not torch.isnan(final_state.energy).any()
 
 
+def test_integrate_converts_init_kwarg(
+    ar_supercell_sim_state: SimState, lj_model: LennardJonesModel
+) -> None:
+    """integrate scales Nose-Hoover `tau` to internal units like `timestep`.
+
+    Otherwise `tau` is ~98x too small for metal units, giving an over-stiff
+    thermostat that diverges on force spikes
+
+    See https://github.com/TorchSim/torch-sim/issues/579 for more info
+    """
+    tau = 0.1  # ps, same convention as `timestep`
+    final = ts.integrate(
+        system=ar_supercell_sim_state,
+        model=lj_model,
+        integrator=ts.Integrator.nvt_nose_hoover,
+        n_steps=1,
+        temperature=100.0,
+        timestep=0.002,
+        init_kwargs={"tau": tau},
+    )
+    expected = tau * ts.units.MetalUnits.time
+    assert torch.allclose(final.chain.tau, torch.full_like(final.chain.tau, expected))
+
+
+def test_integrate_converts_step_kwarg(
+    ar_supercell_sim_state: SimState,
+    lj_model: LennardJonesModel,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """integrate divides inverse-time kwargs (e.g. Langevin `gamma`) by the unit factor.
+
+    The opposite direction from relaxation times: `gamma` is a rate, so it scales as
+    1/time, not time. It is a step kwarg, so it travels through `**integrator_kwargs`
+    to the step function (issue #579 / InverseTimeArg).
+    """
+    gamma = 10.0  # 1/ps, same time convention as `timestep`
+    # gamma is consumed inside the step function and never stored on the state, so
+    # unlike the tau test in test_integrate_converts_persistent_init_kwarg, we must
+    # spy on the step call to see the converted value.
+    received: dict[str, object] = {}
+    init, real_step = ts.integrators.INTEGRATOR_REGISTRY[ts.Integrator.nvt_langevin]
+
+    def spy_step(**kwargs: object) -> MDState:
+        received["gamma"] = kwargs["gamma"]
+        return real_step(**kwargs)
+
+    monkeypatch.setitem(
+        ts.integrators.INTEGRATOR_REGISTRY, ts.Integrator.nvt_langevin, (init, spy_step)
+    )
+    ts.integrate(
+        system=ar_supercell_sim_state,
+        model=lj_model,
+        integrator=ts.Integrator.nvt_langevin,
+        n_steps=1,
+        temperature=100.0,
+        timestep=0.002,
+        gamma=gamma,
+    )
+    assert received["gamma"] == gamma / ts.units.MetalUnits.time
+
+
 def test_integrate_double_nvt_multiple_temperatures(
     ar_double_sim_state: SimState, lj_model: LennardJonesModel
 ) -> None:

--- a/torch_sim/integrators/__init__.py
+++ b/torch_sim/integrators/__init__.py
@@ -74,13 +74,25 @@ Notes:
 """
 
 # ruff: noqa: F401
+import typing
 from collections.abc import Callable
+from dataclasses import dataclass
 from enum import StrEnum
-from typing import Any, Final
+from typing import Any, Final, Literal
 
 import torch_sim as ts
 
-from .md import MDState, initialize_momenta, momentum_step, position_step, velocity_verlet
+from .md import (
+    InversePressureArg,
+    InverseTimeArg,
+    MDState,
+    PressureArg,
+    TimeArg,
+    initialize_momenta,
+    momentum_step,
+    position_step,
+    velocity_verlet,
+)
 from .npt import (
     NPTLangevinAnisotropicState,
     NPTLangevinIsotropicState,
@@ -201,4 +213,53 @@ INTEGRATOR_REGISTRY: Final[
         npt_crescale_init,
         npt_crescale_triclinic_step,
     ),
+}
+
+
+@dataclass(frozen=True, slots=True)
+class UnitKwarg:
+    """Metadata for integrator parameters carrying physical units.
+
+    ``factor`` converts the parameter to internal units (multiply by it).
+    ``channel`` is the function the parameter is used in (either ``"init"``
+    or ``"step"``).
+    """
+
+    factor: float
+    channel: Literal["init", "step"]
+
+
+_UNIT_FACTORS: Final = frozenset(
+    arg.__metadata__[0]
+    for arg in (TimeArg, InverseTimeArg, PressureArg, InversePressureArg)
+)
+
+
+def _collect_unit_kwargs(integrator: Integrator) -> dict[str, UnitKwarg]:
+    """Read the unit-annotated kwargs off an integrator's init/step signatures."""
+    init_fn, step_fn = INTEGRATOR_REGISTRY[integrator]
+    unit_kwargs: dict[str, UnitKwarg] = {}
+    for channel, fn in (("init", init_fn), ("step", step_fn)):
+        hints = typing.get_type_hints(fn, include_extras=True)
+        for name, hint in hints.items():
+            for meta in getattr(hint, "__metadata__", ()):
+                if isinstance(meta, float) and meta in _UNIT_FACTORS:
+                    if name in unit_kwargs:
+                        raise TypeError(
+                            f"{integrator}: unit kwarg {name!r} is annotated in both "
+                            f"the init and step functions, making its `integrate` "
+                            f"channel ambiguous"
+                        )
+                    unit_kwargs[name] = UnitKwarg(float(meta), channel)
+    return unit_kwargs
+
+
+#: Unit-carrying kwargs of each integrator, derived at import time from the
+#: ``TimeArg``/``InverseTimeArg``/``PressureArg``/``InversePressureArg`` annotations
+#: on the registered init/step functions. :func:`torch_sim.runners.integrate` reads
+#: this to unit-convert kwargs.
+INTEGRATOR_UNIT_KWARGS: Final[dict[Integrator, dict[str, UnitKwarg]]] = {
+    integrator: unit_kwargs
+    for integrator in Integrator
+    if (unit_kwargs := _collect_unit_kwargs(integrator))
 }

--- a/torch_sim/integrators/md.py
+++ b/torch_sim/integrators/md.py
@@ -4,6 +4,7 @@ import logging
 import warnings
 from collections.abc import Callable
 from dataclasses import dataclass
+from typing import Annotated
 
 import torch
 
@@ -15,6 +16,13 @@ from torch_sim.units import MetalUnits
 
 
 logger = logging.getLogger(__name__)
+
+
+# The metadata is the factor that converts the kwarg to internal units
+TimeArg = Annotated[float | torch.Tensor | None, MetalUnits.time]
+InverseTimeArg = Annotated[float | torch.Tensor | None, 1 / MetalUnits.time]
+PressureArg = Annotated[float | torch.Tensor, MetalUnits.pressure]
+InversePressureArg = Annotated[float | torch.Tensor | None, 1 / MetalUnits.pressure]
 
 
 @dataclass(kw_only=True)

--- a/torch_sim/integrators/npt.py
+++ b/torch_sim/integrators/npt.py
@@ -11,9 +11,13 @@ import torch
 import torch_sim as ts
 from torch_sim._duecredit import dcite
 from torch_sim.integrators.md import (
+    InversePressureArg,
+    InverseTimeArg,
     MDState,
     NoseHooverChain,
     NoseHooverChainFns,
+    PressureArg,
+    TimeArg,
     construct_nose_hoover_chain,
     initialize_momenta,
     momentum_step,
@@ -407,9 +411,9 @@ def npt_langevin_anisotropic_init(
     *,
     kT: float | torch.Tensor,
     dt: float | torch.Tensor,
-    alpha: float | torch.Tensor | None = None,
-    cell_alpha: float | torch.Tensor | None = None,
-    b_tau: float | torch.Tensor | None = None,
+    alpha: InverseTimeArg = None,
+    cell_alpha: InverseTimeArg = None,
+    b_tau: TimeArg = None,
     **_kwargs: Any,
 ) -> NPTLangevinAnisotropicState:
     """Initialize NPT Langevin state with independent per-dimension cell lengths.
@@ -511,7 +515,7 @@ def npt_langevin_anisotropic_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
+    external_pressure: PressureArg,
 ) -> NPTLangevinAnisotropicState:
     r"""Perform one NPT Langevin step with independent per-dimension cell lengths.
 
@@ -886,9 +890,9 @@ def npt_langevin_isotropic_init(
     *,
     kT: float | torch.Tensor,
     dt: float | torch.Tensor,
-    alpha: float | torch.Tensor | None = None,
-    cell_alpha: float | torch.Tensor | None = None,
-    b_tau: float | torch.Tensor | None = None,
+    alpha: InverseTimeArg = None,
+    cell_alpha: InverseTimeArg = None,
+    b_tau: TimeArg = None,
     **_kwargs: Any,
 ) -> NPTLangevinIsotropicState:
     """Initialize an NPT Langevin state using logarithmic strain coordinate.
@@ -986,7 +990,7 @@ def npt_langevin_isotropic_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
+    external_pressure: PressureArg,
 ) -> NPTLangevinIsotropicState:
     r"""Perform one NPT Langevin step using logarithmic strain coordinate.
 
@@ -1643,8 +1647,8 @@ def npt_nose_hoover_isotropic_init(
     chain_length: int = 3,
     chain_steps: int = 2,
     sy_steps: int = 3,
-    t_tau: float | torch.Tensor | None = None,
-    b_tau: float | torch.Tensor | None = None,
+    t_tau: TimeArg = None,
+    b_tau: TimeArg = None,
     **kwargs: Any,
 ) -> NPTNoseHooverIsotropicState:
     """Initialize the NPT Nose-Hoover state.
@@ -1810,7 +1814,7 @@ def npt_nose_hoover_isotropic_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
+    external_pressure: PressureArg,
 ) -> NPTNoseHooverIsotropicState:
     r"""Perform a complete NPT integration step with Nose-Hoover chain thermostats.
 
@@ -2515,8 +2519,8 @@ def npt_crescale_triclinic_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
-    tau: float | torch.Tensor | None = None,
+    external_pressure: PressureArg,
+    tau: TimeArg = None,
 ) -> NPTCRescaleState:
     r"""Perform one NPT integration step with anisotropic stochastic cell rescaling.
 
@@ -2643,8 +2647,8 @@ def npt_crescale_anisotropic_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
-    tau: float | torch.Tensor | None = None,
+    external_pressure: PressureArg,
+    tau: TimeArg = None,
 ) -> NPTCRescaleState:
     """Perform one NPT integration step with cell rescaling barostat.
 
@@ -2719,8 +2723,8 @@ def npt_crescale_triclinic_average_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
-    tau: float | torch.Tensor | None = None,
+    external_pressure: PressureArg,
+    tau: TimeArg = None,
 ) -> NPTCRescaleState:
     """Perform one NPT integration step with cell rescaling barostat.
 
@@ -2795,8 +2799,8 @@ def npt_crescale_isotropic_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    external_pressure: float | torch.Tensor,
-    tau: float | torch.Tensor | None = None,
+    external_pressure: PressureArg,
+    tau: TimeArg = None,
 ) -> NPTCRescaleState:
     r"""Perform one NPT integration step with isotropic stochastic cell rescaling.
 
@@ -2902,8 +2906,8 @@ def npt_crescale_init(
     *,
     kT: float | torch.Tensor,
     dt: float | torch.Tensor,
-    tau_p: float | torch.Tensor | None = None,
-    isothermal_compressibility: float | torch.Tensor | None = None,
+    tau_p: TimeArg = None,
+    isothermal_compressibility: InversePressureArg = None,
 ) -> NPTCRescaleState:
     """Initialize the NPT cell rescaling state.
 

--- a/torch_sim/integrators/nvt.py
+++ b/torch_sim/integrators/nvt.py
@@ -8,9 +8,11 @@ import torch
 import torch_sim as ts
 from torch_sim._duecredit import dcite
 from torch_sim.integrators.md import (
+    InverseTimeArg,
     MDState,
     NoseHooverChain,
     NoseHooverChainFns,
+    TimeArg,
     construct_nose_hoover_chain,
     initialize_momenta,
     momentum_step,
@@ -143,7 +145,7 @@ def nvt_langevin_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    gamma: float | torch.Tensor | None = None,
+    gamma: InverseTimeArg = None,
 ) -> MDState:
     r"""Perform one complete Langevin dynamics integration step using the BAOAB scheme.
 
@@ -291,7 +293,7 @@ def nvt_nose_hoover_init(
     *,
     kT: float | torch.Tensor,
     dt: float | torch.Tensor,
-    tau: float | torch.Tensor | None = None,
+    tau: TimeArg = None,
     chain_length: int = 3,
     chain_steps: int = 3,
     sy_steps: int = 3,
@@ -711,7 +713,7 @@ def nvt_vrescale_step(
     *,
     dt: float | torch.Tensor,
     kT: float | torch.Tensor,
-    tau: float | torch.Tensor | None = None,
+    tau: TimeArg = None,
 ) -> NVTVRescaleState:
     r"""Perform one complete V-Rescale (CSVR) dynamics integration step.
 

--- a/torch_sim/runners.py
+++ b/torch_sim/runners.py
@@ -18,7 +18,7 @@ from tqdm import tqdm
 
 import torch_sim as ts
 from torch_sim.autobatching import BinningAutoBatcher, InFlightAutoBatcher
-from torch_sim.integrators import INTEGRATOR_REGISTRY, Integrator
+from torch_sim.integrators import INTEGRATOR_REGISTRY, INTEGRATOR_UNIT_KWARGS, Integrator
 from torch_sim.integrators.md import MDState
 from torch_sim.models.interface import ModelInterface
 from torch_sim.optimizers import OPTIM_REGISTRY, FireState, Optimizer, OptimState
@@ -249,7 +249,7 @@ def _write_initial_state(
             trajectory_reporter.report(state, 0, model=model)
 
 
-def integrate[T: SimState](  # noqa: C901
+def integrate[T: SimState](  # noqa: C901, PLR0915
     system: StateLike,
     model: ModelInterface,
     *,
@@ -287,7 +287,7 @@ def integrate[T: SimState](  # noqa: C901
             it's passed to `tqdm` as kwargs.
         init_kwargs (dict[str, Any], optional): Additional keyword arguments for
             integrator init function.
-        **integrator_kwargs: Additional keyword arguments for integrator init function
+        **integrator_kwargs: Additional keyword arguments for integrator step function
 
     Returns:
         T: Final state after integration
@@ -320,6 +320,16 @@ def integrate[T: SimState](  # noqa: C901
             f"integrator must be key from Integrator or a tuple of "
             f"(init_func, step_func), got {type(integrator)}"
         )
+
+    # Like `timestep` above, unit-carrying kwargs (e.g. `tau`, `gamma`,
+    # `external_pressure`) must be converted to internal units per
+    # INTEGRATOR_UNIT_KWARGS
+    init_kwargs = dict(init_kwargs or {})
+    channels = {"init": init_kwargs, "step": integrator_kwargs}
+    for key, meta in INTEGRATOR_UNIT_KWARGS.get(integrator, {}).items():
+        kwargs = channels[meta.channel]
+        if kwargs.get(key) is not None:
+            kwargs[key] = kwargs[key] * meta.factor
     # batch_iterator will be a list if autobatcher is False
     batch_iterator = _configure_batches_iterator(
         initial_state, model, autobatcher=autobatcher
@@ -351,9 +361,7 @@ def integrate[T: SimState](  # noqa: C901
         batch_kT = (
             kTs[:, system_indices] if (system_indices and len(kTs.shape) == 2) else kTs
         )
-        state = init_func(
-            state=state, model=model, kT=batch_kT[0], dt=dt, **init_kwargs or {}
-        )
+        state = init_func(state=state, model=model, kT=batch_kT[0], dt=dt, **init_kwargs)
 
         # set up trajectory reporters
         if autobatcher and trajectory_reporter is not None and og_filenames is not None:

--- a/torch_sim/units.py
+++ b/torch_sim/units.py
@@ -15,7 +15,7 @@ class BaseConstant(float, Enum):
 
     References:
         http://arxiv.org/pdf/1507.07956.pdf
-        https://wiki.fysik.dtu.dk/ase/_modules/ase/units.html#create_units
+        https://docs.ase-lib.org/_modules/ase/units.html#create_units
     """
 
     def __new__(cls, value: float) -> Self:


### PR DESCRIPTION
## Summary

* Feature 1
* Fix 1

## Checklist

Before a pull request can be merged, the following items must be checked:

* [ ] Doc strings have been added in the [Google docstring format](https://sphinxcontrib-napoleon.readthedocs.io/en/latest/example_google.html#example-google).
* [ ] Run [ruff](https://beta.ruff.rs/docs/rules/#pydocstyle-d) on your code.
* [ ] Tests have been added for any new functionality or bug fixes.

<!-- We highly recommended installing the `prek` hooks running in CI locally to speedup the development process. Simply run `pip install prek && prek install` to install the hooks which will check your code before each commit. -->

fixed version of https://github.com/TorchSim/torch-sim/pull/586
```
MD completed
  systems: 16
  precondition wall: 79.293 s
  md wall: 386.878 s
  system-steps/s: 41.357
  peak CUDA memory: 25.090 GB
  bad indices: []
  bad reasons: []
  final temperature K: [315.43124 307.20044 312.35632 292.31323 306.58423 276.70398 300.48325
 306.9538  316.2425  282.4878  304.26224 306.15756 254.9931  301.22366
 269.04944 309.7748 ]
  final energy eV: [-559.7459  -558.1463  -557.8347  -557.28534 -557.3563  -560.15857
 -558.66504 -560.3809  -559.75604 -557.13654 -557.65424 -558.678
 -559.63214 -557.4609  -558.0716  -556.77484]
  final min distance A: [2.1968294902802037, 2.220445678908415, 2.0329850879817677, 2.195226021556654, 1.981977865951136, 2.193242034845892, 2.2171705179385155, 2.1947683840575833, 2.173143383432847, 2.1819499283504364, 2.1929907916179383, 2.2170552769413563, 2.231164529097381, 2.2007128872956376, 2.2006608344266665, 2.2029369811994153]
```



```
"""Minimal reproduction of torch-sim issue #579 (Nose-Hoover `tau` units).

Run:  uv run python repro_579_min.py

The reporter ran batched NVT MD (16 amorphous NaTaCl6 systems, SevenNet-OMNI,
NVT Nose-Hoover, 2 fs, tdamp 200 fs) and got NaN energy/temperature in *some*
batch elements -- with D3 on AND off, and with MatterSim too. ASE stayed finite
under the same physical settings, so it is a torch-sim integrator bug, not a
potential bug.

ROOT CAUSE
    ``ts.integrate`` converts ``timestep`` to internal units but used to forward
    the Nose-Hoover relaxation time ``tau`` unconverted. The reporter passed
    ``tau = 200 fs = 0.2 ps`` and ``timestep = 2 fs = 0.002 ps`` (same
    convention). In metal units time is scaled ~98x, so ``dt`` became ~0.196
    while ``tau`` stayed 0.2 -- i.e. ``tau ~ dt``. A Nose-Hoover chain with
    relaxation time ~= one step has a near-zero thermostat mass and is
    *marginally* unstable: depending on the initial velocity draw, some batch
    systems tip into NaN -- exactly the "some batch elements end with NaN"
    symptom. The fix converts ``tau``/``b_tau`` with the same factor as
    ``timestep`` (torch_sim/runners.py).

Two demos, each comparing BUGGY tau (pre-fix, tau~dt) vs FIXED tau (converted):
  1. Lennard-Jones, single system -- fast, no download, fully deterministic.
  2. SevenNet (7net-0) on the reporter's real 16 structures, batched -- faithful;
     downloads a ~100 MB checkpoint and reproduces the subset-NaN symptom.
"""

from __future__ import annotations

import numpy as np
import torch
from ase import Atoms

import torch_sim as ts
from torch_sim.integrators import nvt_nose_hoover_init, nvt_nose_hoover_step
from torch_sim.models.lennard_jones import LennardJonesModel
from torch_sim.units import MetalUnits

DEV = torch.device("cuda" if torch.cuda.is_available() else "cpu")
DTYPE = torch.float32
DT_PS = 0.002  # 2 fs
TAU_PS = 0.2  # 200 fs
TIME = float(MetalUnits.time)  # ps -> internal (~98.23)


def reporter_structures() -> list[Atoms]:
    """16 packmol-like NaTaCl6 structures (128 atoms, 2.9 g/cm^3), generated in memory.

    Reproduces the reporter's batch: dense NaTaCl6 at box 15.62 A (= 2.9 g/cm^3),
    one structure per seed so divergence hits a marginal subset, not all 16.
    """
    return [lj_single_structure(seed=11001 + i) for i in range(16)]


def lj_single_structure(seed: int = 11001) -> Atoms:
    """Author-like NaTaCl6 (128 atoms, box 15.62, min spacing 2.26 A, no overlap)."""
    box, rng = 15.62, np.random.default_rng(seed)
    numbers = [11] * 16 + [73] * 16 + [17] * 96
    pos: list[np.ndarray] = []
    while len(pos) < len(numbers):
        cand = rng.uniform(0.0, box, size=3)
        if pos:
            d = np.array(pos) - cand
            d -= box * np.round(d / box)
            if np.linalg.norm(d, axis=1).min() < 2.26:
                continue
        pos.append(cand)
    return Atoms(numbers=numbers, positions=np.array(pos), cell=[box] * 3, pbc=True)


def bad_systems(state: ts.state.SimState) -> list[int]:
    return (~torch.isfinite(state.energy)).nonzero().flatten().tolist()


def run_integrate(
    systems: list[Atoms], model, *, tau_ps: float, steps: int
) -> list[int]:
    final = ts.integrate(
        system=systems,
        model=model,
        integrator=ts.Integrator.nvt_nose_hoover,
        n_steps=steps,
        temperature=300.0,
        timestep=DT_PS,
        init_kwargs={"tau": tau_ps, "chain_length": 3, "chain_steps": 1, "sy_steps": 3},
        pbar=False,
    )
    return bad_systems(final)


def lj_demo() -> None:
    print("[1] Lennard-Jones, single system (deterministic, no download)")
    atoms = lj_single_structure()
    # sigma > 2.26 A spacing -> every ion in the repulsive wall (strong forces),
    # a stand-in for the dense ionic melt; divergence is distributed, not a contact.
    model = LennardJonesModel(sigma=3.0, epsilon=0.3, cutoff=7.5, device=DEV, dtype=DTYPE)
    dt = torch.tensor(DT_PS * TIME)
    kT = torch.tensor(300.0 * MetalUnits.temperature)
    # buggy: tau forwarded UNCONVERTED -> 0.2 internal ~= dt
    torch.manual_seed(0)
    s = nvt_nose_hoover_init(
        ts.io.atoms_to_state([atoms], device=DEV, dtype=DTYPE),
        model,
        kT=kT,
        dt=dt,
        tau=TAU_PS,
    )
    for _ in range(200):
        s = nvt_nose_hoover_step(s, model, dt=dt, kT=kT)
    buggy = bad_systems(s)
    # fixed: ts.integrate converts tau like timestep
    fixed = run_integrate([atoms], model, tau_ps=TAU_PS, steps=200)
    print(f"    buggy (tau~dt)   diverged systems = {buggy}  (expect [0])")
    print(f"    fixed (tau*time) diverged systems = {fixed}  (expect [])\n")


def sevennet_demo() -> None:
    print("[2] SevenNet 7net-0, reporter's 16 real structures, batched")
    from torch_sim.models.sevennet import SevenNetModel

    systems = reporter_structures()
    model = SevenNetModel(model="7net-0", device=DEV, dtype=DTYPE)
    # buggy: reconstruct pre-fix internal tau (0.2) by undoing integrate's conversion
    buggy = run_integrate(systems, model, tau_ps=TAU_PS / TIME, steps=200)
    fixed = run_integrate(systems, model, tau_ps=TAU_PS, steps=200)
    print(f"    buggy (tau~dt)   diverged systems = {buggy}  (a marginal subset NaNs)")
    print(f"    fixed (tau*time) diverged systems = {fixed}  (expect [])\n")


def main() -> None:
    print(f"device={DEV}  timestep=2 fs  tau=200 fs  tau/dt(buggy)~1  steps=200\n")
    lj_demo()
    sevennet_demo()


if __name__ == "__main__":
    main()

```